### PR TITLE
Use HelperPluginManager instead of HelperBroker

### DIFF
--- a/src/ZfcTwig/Service/EnvironmentFactory.php
+++ b/src/ZfcTwig/Service/EnvironmentFactory.php
@@ -15,14 +15,14 @@ class EnvironmentFactory implements FactoryInterface
     {
         $config = $serviceLocator->get('Configuration');
         $config = $config['zfctwig'];
-        $broker = $serviceLocator->get('ViewHelperBroker');
+        $manager = $serviceLocator->get('ViewHelperManager');
 
         $loader = new AbsoluteFilesystem($config['paths']);
         $loader->setFallbackResolver($serviceLocator->get('ViewTemplatePathStack'));
 
         $twig = new Environment($loader, $config['config']);
         $twig->addExtension(new Extension($twig));
-        $twig->setBroker($broker);
+        $twig->setManager($manager);
 
         foreach($config['extensions'] as $ext) {
             if (!is_string($ext)) {

--- a/src/ZfcTwig/Twig/Environment.php
+++ b/src/ZfcTwig/Twig/Environment.php
@@ -4,21 +4,21 @@ namespace ZfcTwig\Twig;
 
 use Twig_Environment;
 use ZfcTwig\Twig\Func\ViewHelper;
-use Zend\View\HelperBroker;
+use Zend\View\HelperPluginManager;
 
 class Environment extends Twig_Environment
 {
     /**
-     * @var \Zend\View\HelperBroker
+     * @var \Zend\View\HelperPluginManager
      */
-    protected $broker;
+    protected $manager;
 
     /**
-     * @return \Zend\View\HelperBroker
+     * @return \Zend\View\HelperPluginManager
      */
-    public function broker()
+    public function manager()
     {
-        return $this->broker;
+        return $this->manager;
     }
 
     /**
@@ -26,16 +26,16 @@ class Environment extends Twig_Environment
      */
     public function plugin($name)
     {
-        return $this->broker()->load($name);
+        return $this->manager()->get($name);
     }
 
     /**
-     * @param \Zend\View\HelperBroker $broker
+     * @param \Zend\View\HelperPluginManager $manager
      * @return Environment
      */
-    public function setBroker(HelperBroker $broker)
+    public function setManager(HelperPluginManager $manager)
     {
-        $this->broker = $broker;
+        $this->manager = $manager;
         return $this;
     }
 


### PR DESCRIPTION
Following the updates to zf2 to use AbstractPluginManager, Zend\View\HelperBroker was no longer available.

(see https://github.com/zendframework/zf2/commit/d12447e085b32073bb74b47782a0642468097cf4)

As such, attempting to load a template using any view helpers resulted in the following fatal error:

Catchable fatal error: Argument 1 passed to ZfcTwig\Twig\Environment::setBroker() must be an instance of Zend\View\HelperBroker, instance of Zend\View\HelperPluginManager given, called in /vagrant/vendor/zf-commons/zfc-twig/src/ZfcTwig/Service/EnvironmentFactory.php on line 25 and defined in /vagrant/vendor/zf-commons/zfc-twig/src/ZfcTwig/Twig/Environment.php on line 36
