### PR TITLE
Set the Renderer in the View Helper Manager

### DIFF
--- a/src/ZfcTwig/Service/ViewRendererFactory.php
+++ b/src/ZfcTwig/Service/ViewRendererFactory.php
@@ -19,7 +19,11 @@ class ViewRendererFactory implements FactoryInterface
         $resolver = $serviceLocator->get('ViewResolver');
 
         $renderer = new Renderer();
-        $renderer->setEngine($serviceLocator->get('TwigEnvironment'));
+
+        $engine = $serviceLocator->get('TwigEnvironment');
+        $engine->manager()->setRenderer($renderer);
+
+        $renderer->setEngine($engine);
         $renderer->setResolver($resolver);
 
         return $renderer;


### PR DESCRIPTION
This would have been done in the EngineFactory - however - that creates
a circular dependency.
