### PR TITLE
fix explode parameter order

### DIFF
--- a/src/ZfcTwig/Twig/Helper/Trigger.php
+++ b/src/ZfcTwig/Twig/Helper/Trigger.php
@@ -61,7 +61,7 @@ class Trigger
     {
         $alias = 'zfc-twig';
         if (strpos($eventName, ':')!==false){
-            $aux = explode($eventName, ':');
+            $aux = explode(':', $eventName);
             $alias = $aux[0];
             $eventName = $aux[1];
         }


### PR DESCRIPTION
explode requires the delimiter to be the first parameter
