### PR TITLE
Removed unneeded setRenderer

### DIFF
--- a/src/ZfcTwig/Service/ViewRendererFactory.php
+++ b/src/ZfcTwig/Service/ViewRendererFactory.php
@@ -25,7 +25,6 @@ class ViewRendererFactory implements FactoryInterface
         $renderer->setSuffix(isset($config['suffix']) ? $config['suffix'] : 'twig');
 
         $engine = $serviceLocator->get('TwigEnvironment');
-        $engine->manager()->setRenderer($renderer);
         $renderer->setHelperPluginManager($engine->manager());
 
         $renderer->setEngine($engine);


### PR DESCRIPTION
The renderer is automatically attached when calling the [setHelperPluginManager](https://github.com/zendframework/zf2/blob/master/library/Zend/View/Renderer/PhpRenderer.php#L288) method at [this line](https://github.com/zendframework/zf2/blob/master/library/Zend/View/Renderer/PhpRenderer.php#L305)
