### PR TITLE
Changed resolve logic

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -20,9 +20,10 @@ class Module
         return array(
             'aliases' => array(),
             'factories' => array(
-                'TwigEnvironment'  => 'ZfcTwig\Service\EnvironmentFactory',
-                'TwigViewRenderer' => 'ZfcTwig\Service\ViewRendererFactory',
-                'TwigViewStrategy' => 'ZfcTwig\Service\ViewStrategyFactory',
+                'TwigEnvironment'   => 'ZfcTwig\Service\EnvironmentFactory',
+                'TwigViewRenderer'  => 'ZfcTwig\Service\ViewRendererFactory',
+                'TwigViewStrategy'  => 'ZfcTwig\Service\ViewStrategyFactory',
+                'TwigResolver'      => 'ZfcTwig\Service\ViewResolverFactory',
             )
         );
     }

--- a/src/ZfcTwig/Service/EnvironmentFactory.php
+++ b/src/ZfcTwig/Service/EnvironmentFactory.php
@@ -3,11 +3,11 @@
 namespace ZfcTwig\Service;
 
 use InvalidArgumentException;
-use ZfcTwig\Twig\Loader\Filesystem;
-use ZfcTwig\Twig\Environment;
-use ZfcTwig\Twig\Extension;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcTwig\Twig\Environment;
+use ZfcTwig\Twig\Extension;
+use ZfcTwig\View\Resolver;
 
 class EnvironmentFactory implements FactoryInterface
 {
@@ -15,15 +15,10 @@ class EnvironmentFactory implements FactoryInterface
     {
         $config = $serviceLocator->get('Configuration');
         $config = $config['zfctwig'];
+ 
         $manager = clone $serviceLocator->get('ViewHelperManager');
 
-        $loader = new Filesystem(array());
-        $resolver = $serviceLocator->get('ViewResolver');
-        $loader->setFallbackResolver($resolver);
-        
-        foreach ($config['namespaces'] as $namespace => $path) {
-            $loader->addPath($path, $namespace);
-        }
+        $loader = $serviceLocator->get('TwigResolver');
 
         $twig = new Environment($loader, $config['config']);
         $twig->addExtension(new Extension($twig, $serviceLocator));
@@ -35,7 +30,6 @@ class EnvironmentFactory implements FactoryInterface
             }
             $twig->addExtension(new $ext);
         }
-
 
         return $twig;
     }

--- a/src/ZfcTwig/Service/ViewRendererFactory.php
+++ b/src/ZfcTwig/Service/ViewRendererFactory.php
@@ -14,21 +14,14 @@ class ViewRendererFactory implements FactoryInterface
         $config = $serviceLocator->get('Configuration');
         $config = $config['zfctwig'];
 
-        $pathResolver = clone $serviceLocator->get('ViewTemplatePathStack');
-        $pathResolver->setDefaultSuffix($config['suffix']);
-
-        $resolver = $serviceLocator->get('ViewResolver');
-        $resolver->attach($pathResolver, 2);
-
         $renderer = new Renderer();
         $renderer->setSuffixLocked(isset($config['suffix_locked']) ? $config['suffix_locked'] : false);
         $renderer->setSuffix(isset($config['suffix']) ? $config['suffix'] : 'twig');
 
         $engine = $serviceLocator->get('TwigEnvironment');
         $renderer->setHelperPluginManager($engine->manager());
-
         $renderer->setEngine($engine);
-        $renderer->setResolver($resolver);
+        $renderer->setResolver($serviceLocator->get('TwigResolver'));
 
         return $renderer;
     }

--- a/src/ZfcTwig/Service/ViewResolverFactory.php
+++ b/src/ZfcTwig/Service/ViewResolverFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace ZfcTwig\Service;
+
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcTwig\View\Resolver;
+
+class ViewResolverFactory implements FactoryInterface
+{
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        $config = $serviceLocator->get('Configuration');
+        $config = $config['zfctwig'];
+
+        $pathResolver = clone $serviceLocator->get('ViewTemplatePathStack');
+        $pathResolver->setDefaultSuffix($config['suffix']);
+
+        $resolver = clone $serviceLocator->get('ViewResolver');
+        $resolver->attach($pathResolver, 2);
+
+        $loader = new Resolver(array());
+        $loader->setFallbackResolver($resolver);
+        
+        foreach ($config['namespaces'] as $namespace => $path) {
+            $loader->addPath($path, $namespace);
+        }
+        
+        return $loader;
+    }
+}
+

--- a/src/ZfcTwig/Twig/Loader/Filesystem.php
+++ b/src/ZfcTwig/Twig/Loader/Filesystem.php
@@ -26,7 +26,7 @@ class Filesystem extends Twig_Loader_Filesystem
         $this->fallbackResolver = $fallbackResolver;
         return $this;
     }
-    
+
     /**
      * @param string $name
      * @return string
@@ -52,8 +52,7 @@ class Filesystem extends Twig_Loader_Filesystem
             $namespace = substr($name, 1, $pos - 1);
             $name      = substr($name, $pos + 1);
         }
-
-
+        
         if (!isset($this->paths[$namespace])) {
             throw new Twig_Error_Loader(sprintf('There are no registered paths for namespace "%s".', $namespace));
         }

--- a/src/ZfcTwig/View/Resolver.php
+++ b/src/ZfcTwig/View/Resolver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ZfcTwig\View;
+
+use Zend\View\Renderer\RendererInterface;
+use Zend\View\Resolver\ResolverInterface;
+use ZfcTwig\Twig\Loader\Filesystem;
+
+class Resolver extends Filesystem implements ResolverInterface
+{
+    /**
+     * @param string $name
+     * @param RendererInterface $renderer
+     */
+    public function resolve($name, RendererInterface $renderer = null)
+    {
+        return $this->findTemplate($name);
+    }
+}


### PR DESCRIPTION
- Changed resolve logic so it works with both .twig and .phtml extension.
- Removed the usage of the `exists` which was not available in `twig:1.10.*` as required by the composer configuration
- Merged Twig and ZfcTwig resolvers together in 1 object so they both use the same method to check and resolve their templates
- Fixes #26
