### PR TITLE
Always provide empty array at minimum

### DIFF
--- a/src/ZfcTwig/View/Renderer/TwigRenderer.php
+++ b/src/ZfcTwig/View/Renderer/TwigRenderer.php
@@ -117,7 +117,7 @@ class TwigRenderer implements RendererInterface
      * @return string|null The script output.
      * @throws \Zend\View\Exception\DomainException
      */
-    public function render($nameOrModel, $values = null)
+    public function render($nameOrModel, $values = array())
     {
         if ($nameOrModel instanceof ModelInterface) {
             $model       = $nameOrModel;


### PR DESCRIPTION
This follow my previous PR which introduced a small mistake. The default values has to be en empty array, not null, otherwise renderer throw an exception.
