### PR TITLE
Fix template stack loader to use configured suffix

### DIFF
--- a/src/ZfcTwig/Service/Loader/TemplatePathStackFactory.php
+++ b/src/ZfcTwig/Service/Loader/TemplatePathStackFactory.php
@@ -16,9 +16,14 @@ class TemplatePathStackFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
+        $config = $serviceLocator->get('Configuration');
+        $config = $config['zfctwig'];
+
         /** @var $templateStack \Zend\View\Resolver\TemplatePathStack */
         $zfTemplateStack = $serviceLocator->get('ViewTemplatePathStack');
-        $templateStack   = new TemplatePathStack($zfTemplateStack->getPaths()->toArray());
+
+        $templateStack = new TemplatePathStack($zfTemplateStack->getPaths()->toArray());
+        $templateStack->setDefaultSuffix($config['suffix']);
 
         return $templateStack;
     }


### PR DESCRIPTION
The `TemplatePathStack` loader did not respect the default file suffix configured in `zfctwig.suffix`. This patch correct its behaviour so it matches the documentation and the `TemplateMap` loader.
