### PR TITLE
Return false for undefined functions, not null

### DIFF
--- a/src/ZfcTwig/Service/TwigEnvironmentFactory.php
+++ b/src/ZfcTwig/Service/TwigEnvironmentFactory.php
@@ -28,7 +28,7 @@ class TwigEnvironmentFactory implements FactoryInterface
                 if ($helperPluginManager->has($name)) {
                     return new ViewHelper($name);
                 }
-                return null;
+                return false;
             });
         }
 


### PR DESCRIPTION
Calling an undefined function like `{{ foo('bar') }}` results in a fatal error being thrown:

```
Fatal error: Call to a member function getSafe() on a non-object in
.../vendor/twig/twig/lib/Twig/NodeVisitor/SafeAnalysis.php on line 84
```

According to the Twig docs for [registerUndefinedFunctionCallback()](http://twig.sensiolabs.org/doc/recipes.html#defining-undefined-functions-and-filters-on-the-fly), `false` should be returned instead of `null`, if the requested function is undefined.

This fix changes the return value so the correct error message is thrown:

```
The function "foo" does not exist in "..." at line 4
```
