### PR TITLE
Added a Twig filter to pull the exception class name from an exception

### DIFF
--- a/src/ZfcTwig/Twig/Extension/ZfcTwig.php
+++ b/src/ZfcTwig/Twig/Extension/ZfcTwig.php
@@ -22,6 +22,19 @@ class ZfcTwig extends Twig_Extension
         $this->renderer = $renderer;
     }
 
+    public function getFilters()
+    {
+        return array(
+            'exception_class' => new \Twig_Filter_Method($this, 'exceptionClass'),
+        );
+    }
+
+    public function exceptionClass(\Exception $exception)
+    {
+       return get_class($exception);
+    }
+
+
     /**
      * @return \Zend\View\HelperPluginManager
      */


### PR DESCRIPTION
I was trying to transform my error view PHP template to a twig template. Doing this I was not really able to replace the get_class($exception) part of it. First I tried to make an own version of the ExceptionStrategy which puts more variables into the ViewModel but the implementation didn't feel clean and maybe a filter is better.

If you are liking this addition, should I also make application/error/index.twig and application/error/404.twig examples in this pull-request?
