### PR TITLE
TwigRenderer to handle additional grand children

### DIFF
--- a/src/ZfcTwig/View/Renderer/TwigRenderer.php
+++ b/src/ZfcTwig/View/Renderer/TwigRenderer.php
@@ -203,18 +203,18 @@ class TwigRenderer implements RendererInterface, TreeRendererInterface
                 $values['content'] = '';
             }
             foreach($model as $child) {
-                $variables = (array) $child->getVariables();
-                if ($child->hasChildren()) {
-                    foreach ($child->getChildren() as $grandChild) {
-                        $template = $this->resolver->resolve($grandChild->getTemplate(), $this);
-                        if ($template) {
-                            $variables[$grandChild->captureTo()] = $template->render((array) $grandChild->getVariables());
-                        }
-                    }
-                } 
                 /** @var \Zend\View\Model\ViewModel $child */
                 $template = $this->resolver->resolve($child->getTemplate(), $this);
                 if ($template) {
+                    $variables = (array) $child->getVariables();
+                    if ($child->hasChildren()) {
+                        foreach ($child->getChildren() as $grandChild) {
+                            $childTemplate = $this->resolver->resolve($grandChild->getTemplate(), $this);
+                            if ($childTemplate) {
+                                $variables[$grandChild->captureTo()] = $childTemplate->render((array) $grandChild->getVariables());
+                            }
+                        }
+                    } 
                     return $template->render($variables);
                 }
                 $child->setOption('has_parent', true);


### PR DESCRIPTION
For my use case herewith an extension to the renderer to render grand children ViewModel's. It adds the template snippets of the children as captureTo variables for the child to consume.
