### PR TITLE
Inject the service manager here to prevent the latest zend-mvc from throwing deprecation notices

### DIFF
--- a/src/ZfcTwig/View/HelperPluginManagerFactory.php
+++ b/src/ZfcTwig/View/HelperPluginManagerFactory.php
@@ -28,6 +28,7 @@ class HelperPluginManagerFactory implements FactoryInterface
 
         $baseManager = $serviceLocator->get('ViewHelperManager');
         $twigManager = new HelperPluginManager(new Config($managerOptions));
+        $twigManager->setServiceLocator($serviceLocator);
         $twigManager->addPeeringServiceManager($baseManager);
 
         foreach ($managerConfigs as $configClass) {


### PR DESCRIPTION
AbstractPluginManager that don't have the SL injected cause panic with the latest zend-servicemanager release. See \Zend\Mvc\Service\ServiceManagerConfig

```
// For service locator aware plugin managers that do not have
                // the service locator already injected, inject it, but emit a
                // deprecation notice.
                if ($instance instanceof ServiceLocatorAwareInterface
                    && $instance instanceof AbstractPluginManager
                    && ! $instance->getServiceLocator()
                ) {
                    trigger_error(sprintf(
                        'ServiceLocatorAwareInterface is deprecated and will be removed in version 3.0, along '
                        . 'with the ServiceLocatorAwareInitializer. Please update your %s plugin manager factory '
                        . 'to inject the parent service locator via the constructor.',
                        get_class($instance)
                    ), E_USER_DEPRECATED);
                    $instance->setServiceLocator($container);
                }
```
